### PR TITLE
Parking A81 Herrenberg is closed until spring 2022

### DIFF
--- a/parking_lots.geojson
+++ b/parking_lots.geojson
@@ -322,9 +322,27 @@
         ]
       },
       "properties": {
-        "name": "Parken + Mitfahren A81/B296",
+        "name": "Parken + Mitfahren A81/B296 (Derzeit wg. Bauarbeiten gesperrt)",
         "address": "Parkplatz bei der Autobahnmeisterei",
         "capacity": 10,
+        "free": 0,
+        "type": "Park-Carpool",
+        "state": "closed"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+         8.89462,
+        48.57867
+        ]
+      },
+      "properties": {
+        "name": "Parken + Mitfahren A81 Herrenberg/Gültstein (Ersatzfläche)",
+        "address": "Parkplatz südl. Ohmstraße Gültstein",
+        "capacity": 50,
         "type": "Park-Carpool"
       }
     }

--- a/parking_lots.geojson
+++ b/parking_lots.geojson
@@ -309,6 +309,7 @@
         "address": "71083 Herrenberg",
         "capacity": 10,
         "type": "Wohnmobilparkplatz",
+        "state": "closed",
         "url": "https://www.herrenberg.de/de/Stadtleben/Erlebnis-Herrenberg/Tourismus-Gaeste/uebernachten/Wohnmobilstellplaetze"
       }
     },

--- a/thingsboard-to-parkapi
+++ b/thingsboard-to-parkapi
@@ -118,7 +118,7 @@ def fetch_static_lots():
                 "address":          props["name"],
                 "name":             props["name"],
                 "forecast":         False,
-                "state":            "nodata",
+                "state":            props.get("state", "nodata")
                 "coords" : {
                     "lat":          float(coords[1]),
                     "lng":          float(coords[0])


### PR DESCRIPTION
The Carpool parking at A81 Herrenberg is closed until spring 2022.

This PR sets it's state to `closed`(and handles the transfer to the ParkAPI output), and introduced the replacement parking. Note that it's capacity is not known to me, but is necessary.