### PR TITLE
Adds notes property to communicate customer information

### DIFF
--- a/parking_lots.geojson
+++ b/parking_lots.geojson
@@ -310,7 +310,11 @@
         "capacity": 10,
         "type": "Wohnmobilparkplatz",
         "state": "closed",
-        "url": "https://www.herrenberg.de/de/Stadtleben/Erlebnis-Herrenberg/Tourismus-Gaeste/uebernachten/Wohnmobilstellplaetze"
+        "url": "https://www.herrenberg.de/de/Stadtleben/Erlebnis-Herrenberg/Tourismus-Gaeste/uebernachten/Wohnmobilstellplaetze",
+        "notes": {
+          "de": "Der Herrenberger Wohnmobil Stellplatz ist aufgrund der aktuellen Situation auch noch im Dezember gesperrt.",
+          "en": "Due to COVID19, the camping site 'Wohnmobilhafen' is currently closed."
+        }
       }
     },
     {
@@ -328,7 +332,11 @@
         "capacity": 10,
         "free": 0,
         "type": "Park-Carpool",
-        "state": "closed"
+        "state": "closed",
+        "notes": {
+          "de": "Derzeit wegen Bauarbeiten gesperrt bis voraussichtlich Frühjahr 2022.",
+          "en": "Currently closed due tu construction works until spring 2022." 
+        }
       }
     },
     {

--- a/thingsboard-to-parkapi
+++ b/thingsboard-to-parkapi
@@ -130,7 +130,8 @@ def fetch_static_lots():
                 "free":             props.get("free"),
                 "url":              props.get("url"),
                 "fee_hours":        props.get("fee_hours"),
-                "opening_hours":    props.get("opening_hours")
+                "opening_hours":    props.get("opening_hours"),
+                "notes":            props.get("notes")
             }
             res.append(clean_nones(l))
 


### PR DESCRIPTION
ParkAPI does not yet include a property to communicate customer related announcements or description infos. This PR nevertheless adds this as custom extension to the Herrenberg feed.