### PR TITLE
feat: use freeShortTermSpaces where available

### DIFF
--- a/thingsboard-to-parkapi
+++ b/thingsboard-to-parkapi
@@ -60,11 +60,11 @@ def fetch_dynamic_lot(base_url, auth_headers, id):
         attribute_url = f"{base_url}/plugins/telemetry/ASSET/{id}/values/attributes?keys=address,latitude,longitude"
         attrs = requests.get(attribute_url, headers=auth_headers).json()
 
-        timeseries_url = f"{base_url}/plugins/telemetry/ASSET/{id}/values/timeseries?keys=latestSumParkingState,SumOccupied,TotalParking_mapping"
+        timeseries_url = f"{base_url}/plugins/telemetry/ASSET/{id}/values/timeseries?keys=latestSumParkingState,SumOccupied,TotalParking_mapping,freeShortTermSpaces"
         timeseries = requests.get(timeseries_url, headers=auth_headers).json()
         total = get_timeseries_value(timeseries, "TotalParking_mapping")
         occupied = get_timeseries_value(timeseries, "latestSumParkingState")
-        free = total - occupied
+        free = get_timeseries_value(timeseries, "freeShortTermSpaces") or total - occupied
 
         address = get_attribute(attrs, "address")
         return {


### PR DESCRIPTION
This PR requests `freeShortTermSpaces` from the thingsboard and, if available, will use it as value for free parkings.

Fixes https://github.com/stadtnavi/digitransit-ui/issues/966
